### PR TITLE
Add option `stream` for computing signature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
   "typing_extensions >=3.7; python_version<'3.8'",
   "jax>=0.3.10",
   "equinox",
-  "jaxlib"
+  "jaxlib",
+  "jaxtyping"
 ]
 
 [project.optional-dependencies]
@@ -135,6 +136,7 @@ select = [
 extend-ignore = [
   "PLR",    # Design related pylint codes
   "E501",   # Line too long
+  "F722",   # Exclude due to jaxtyping
 ]
 target-version = "py38"
 typing-modules = ["signax._compat.typing"]

--- a/src/signax/module.py
+++ b/src/signax/module.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ("SignatureTransform",)
+__all__ = ("SignatureTransform", "LogSignatureTransform")
 
 import equinox as eqx
 from jaxtyping import Array, Float

--- a/src/signax/module.py
+++ b/src/signax/module.py
@@ -7,7 +7,7 @@ __all__ = ("SignatureTransform",)
 import equinox as eqx
 from jaxtyping import Array, Float
 
-from signax.signatures import signature
+from signax.signatures import logsignature, signature
 from signax.utils import flatten
 
 
@@ -26,3 +26,20 @@ class SignatureTransform(eqx.Module):
         key: Any | None = None,
     ) -> Array:
         return flatten(signature(path, self.depth, self.stream))
+
+
+class LogSignatureTransform(eqx.Module):
+    depth: int
+    stream: bool
+
+    def __init__(self, depth: int, stream: bool) -> None:
+        self.depth = depth
+        self.stream = stream
+
+    def __call__(
+        self,
+        path: Float[Array, "path_len dim"],
+        *,
+        key: Any | None = None,
+    ) -> Array:
+        return flatten(logsignature(path, self.depth, self.stream))

--- a/src/signax/module.py
+++ b/src/signax/module.py
@@ -15,7 +15,7 @@ class SignatureTransform(eqx.Module):
     depth: int
     stream: bool
 
-    def __init__(self, depth: int, stream: bool) -> None:
+    def __init__(self, depth: int, stream: bool = False) -> None:
         self.depth = depth
         self.stream = stream
 
@@ -32,7 +32,7 @@ class LogSignatureTransform(eqx.Module):
     depth: int
     stream: bool
 
-    def __init__(self, depth: int, stream: bool) -> None:
+    def __init__(self, depth: int, stream: bool = False) -> None:
         self.depth = depth
         self.stream = stream
 

--- a/src/signax/module.py
+++ b/src/signax/module.py
@@ -2,42 +2,27 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = (
-    "SignatureTransform",
-    "SignatureCombine",
-)
+__all__ = ("SignatureTransform",)
 
 import equinox as eqx
-import jax
+from jaxtyping import Array, Float
 
-from signax.signatures import signature, signature_combine
-from signax.utils import flatten, unravel_signature
+from signax.signatures import signature
+from signax.utils import flatten
 
 
 class SignatureTransform(eqx.Module):
     depth: int
+    stream: bool
 
-    def __init__(self, depth: int):
+    def __init__(self, depth: int, stream: bool) -> None:
         self.depth = depth
+        self.stream = stream
 
     def __call__(
         self,
-        path: jax.Array,
+        path: Float[Array, "path_len dim"],
         *,
         key: Any | None = None,
-    ) -> jax.Array:
-        return flatten(signature(path, self.depth))
-
-
-class SignatureCombine(eqx.Module):
-    dim: int
-    depth: int
-
-    def __init__(self, dim: int, depth: int):
-        self.dim = dim
-        self.depth = depth
-
-    def __call__(self, signature1: jax.Array, signature2: jax.Array):
-        sig1 = unravel_signature(signature1, self.dim, self.depth)
-        sig2 = unravel_signature(signature2, self.dim, self.depth)
-        return flatten(signature_combine(sig1, sig2))
+    ) -> Array:
+        return flatten(signature(path, self.depth, self.stream))

--- a/src/signax/signatures.py
+++ b/src/signax/signatures.py
@@ -145,8 +145,13 @@ def signature_batch(
     return bulk_signature
 
 
-def logsignature(path: Float[Array, "path_len dim"], depth: int) -> list[Array]:
-    return signature_to_logsignature(signature(path, depth))
+def logsignature(
+    path: Float[Array, "path_len dim"], depth: int, stream: bool = False
+) -> list[Array]:
+    sig = signature(path, depth, stream)
+    if stream:
+        return jax.vmap(signature_to_logsignature)(sig)
+    return signature_to_logsignature(sig)
 
 
 def signature_to_logsignature(

--- a/src/signax/signatures.py
+++ b/src/signax/signatures.py
@@ -145,7 +145,7 @@ def signature_batch(
     return bulk_signature
 
 
-def logsignature(path, depth):
+def logsignature(path: Float[Array, "path_len dim"], depth: int) -> list[Array]:
     return signature_to_logsignature(signature(path, depth))
 
 

--- a/src/signax/tensor_ops.py
+++ b/src/signax/tensor_ops.py
@@ -82,13 +82,6 @@ def mult_inner(
 
     this function returns
         $sum_{i=1}^n A_i x B_{n - i}$
-
-
-    Note this is hard to convert to `jax.lax.fori_loop`.
-    I don't know if it's possible. Several attempts but
-    `TracerIntergerConversionError` is encountered because
-    getting index of a list (it's okay to get index of ndarray
-    but not for lists)
     """
     return sum(
         [

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from numpy.random import default_rng
 
-from signax.module import SignatureTransform
+from signax.module import LogSignatureTransform, SignatureTransform
 
 rng = default_rng()
 
@@ -16,4 +16,15 @@ def test_signature_module(stream):
     x = rng.standard_normal((length, dim))
 
     model = SignatureTransform(depth=depth, stream=stream)
+    model(x)
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_logsignature_module(stream):
+    depth = 3
+    length = 100
+    dim = 5
+    x = rng.standard_normal((length, dim))
+
+    model = LogSignatureTransform(depth=depth, stream=stream)
     model(x)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+from numpy.random import default_rng
+
+from signax.module import SignatureTransform
+
+rng = default_rng()
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_signature_module(stream):
+    depth = 3
+    length = 100
+    dim = 5
+    x = rng.standard_normal((length, dim))
+
+    model = SignatureTransform(depth=depth, stream=stream)
+    model(x)

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
+import pytest
 import signatory
 import torch
 from numpy.random import default_rng
@@ -56,20 +57,24 @@ def test_multi_signature_combine():
     assert jnp.allclose(jax_output, torch_output)
 
 
-def test_signature_batch():
+@pytest.mark.parametrize("stream", [True, False])
+def test_signature_batch(stream):
     depth = 3
 
     # no remainder case
     length = 1001
-    dim = 100
+    dim = 5
     n_chunks = 10
 
     path = rng.standard_normal((length, dim))
-    jax_signature = signature_batch(path, depth, n_chunks)
-    jax_signature = jnp.concatenate([jnp.ravel(x) for x in jax_signature])
+    jax_signature = signature_batch(path, depth, n_chunks, stream=stream)
+    ravel_fn = jax.vmap(jnp.ravel) if stream else jnp.ravel
+    jax_signature = jnp.concatenate([ravel_fn(x) for x in jax_signature], axis=-1)
 
     torch_path = torch.tensor(path)
-    torch_signature = signatory.signature(torch_path[None, ...], depth=depth)
+    torch_signature = signatory.signature(
+        torch_path[None, ...], depth=depth, stream=stream
+    )
     torch_signature = jnp.array(torch_signature.numpy())
 
     assert jnp.allclose(jax_signature, torch_signature)
@@ -78,11 +83,33 @@ def test_signature_batch():
     length = 1005
     path = rng.standard_normal((length, dim))
 
-    jax_signature = signature_batch(path, depth, n_chunks)
-    jax_signature = jnp.concatenate([jnp.ravel(x) for x in jax_signature])
+    jax_signature = signature_batch(path, depth, n_chunks, stream)
+    jax_signature = jnp.concatenate([ravel_fn(x) for x in jax_signature], axis=-1)
 
     torch_path = torch.tensor(path)
-    torch_signature = signatory.signature(torch_path[None, ...], depth=depth)
+    torch_signature = signatory.signature(
+        torch_path[None, ...], depth=depth, stream=stream
+    )
+    torch_signature = jnp.array(torch_signature.numpy())
+
+    assert jnp.allclose(jax_signature, torch_signature)
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_signature(stream):
+    depth = 3
+    length = 100
+    dim = 5
+
+    path = rng.standard_normal((length, dim))
+    jax_signature = signature(path, depth=depth, stream=stream)
+    ravel_fn = jax.vmap(jnp.ravel) if stream else jnp.ravel
+    jax_signature = jnp.concatenate([ravel_fn(x) for x in jax_signature], axis=-1)
+
+    torch_path = torch.tensor(path)
+    torch_signature = signatory.signature(
+        torch_path[None, ...], depth=depth, stream=stream
+    )
     torch_signature = jnp.array(torch_signature.numpy())
 
     assert jnp.allclose(jax_signature, torch_signature)


### PR DESCRIPTION
The update in this PR allows `signax.signature` to support `stream` option.

`signax.signature(path, depth, stream=True)` will compute signature for stream data. That is, suppose that we have a stream data $\mathbf{x} = (x_1, x_2, \dots, x_n)$, and $\mathbf{x}_k = (x_1, x_2, \dots, x_k)$. With `stream=True`, the function will return

$$(Sig(\mathbf{x}_2), Sig(\mathbf{x}_3, \dots, Sig(\mathbf{x}_n))$$

Some minor updates:
 - using `jaxtyping` for type anotation (but not clear how we can anotate the type of `list[Array]` with specific dimension of tensor algebera yet)
 - Remove `SignatureCombine` (it is better to just call `signax.signature_combine`)
 - Add `LogSignatureTransform` module (with `stream` option)