### PR TITLE
Fix CI and log signature test in `word` mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,6 @@ jobs:
           python -m pip install --upgrade setuptools pip wheel
           python -m pip install .[test]
 
-      - name: Install heavy deps for testing (signatory + torch)
-        run: |
-          python -m pip install torch==1.9.0
-          python -m pip install signatory==1.2.6.1.9.0  --no-cache-dir --force-reinstall
-
       - name: Test package
         run: >-
           python -m pytest -ra --cov --cov-report=xml --cov-report=term

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
           python -m pip install --upgrade setuptools pip wheel
           python -m pip install .[test]
 
+      - name: Install iisignature for testing
+        run: |
+          python -m pip install iisignature
+
       - name: Test package
         run: >-
           python -m pytest -ra --cov --cov-report=xml --cov-report=term


### PR DESCRIPTION
- Now CI no longer depends on `signatory` installation. 
- Small fix on log signature test for the specific `word` option.