### PR TITLE
Fix typo in `signature` docstring.

### DIFF
--- a/src/signax/signatures.py
+++ b/src/signax/signatures.py
@@ -38,7 +38,7 @@ def signature(
         path: size (length, dim) or (batch, length, dim)
         depth: signature is truncated at this depth
         stream: whether to handle `path` as a stream. Default is False
-        flatten: whether to flatten the output. Default is False
+        flatten: whether to flatten the output. Default is True
         num_chunks: number of chunks to use. Default is 1. If > 1, path will be divided into
         chunks to compute signatures. Then, obtained signatures are combined (using Chen's identity).
 


### PR DESCRIPTION
The `flatten` parameter for `signax.signature` was documented as defaulting to `False`, but was implemented to default to `True`. This commit updates the documentation to match the implementation.

The choice to update the docstring, rather than the implementation default is to avoid making any breaking changes for downstream users that depend on the existing defaults.