### PR TITLE
feat: Pallas GPU kernels and flat-buffer restricted_exp (P3 draft)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,4 @@ isort.required-imports = ["from __future__ import annotations"]
 "src/signax/signatures.py" = ["ARG001", "ARG005"]  # unused arguments
 "src/signax/module.py" = ["ARG002"]  # unused argument key in __call__ of Module (equinox)
 "examples/nets.py" = ["ARG002"]      # unused argument key in __call__ of Module (equinox)
+"src/signax/pallas_kernels.py" = ["ARG001", "ARG002"]  # kernel ref args read/written via side-effects

--- a/src/signax/__init__.py
+++ b/src/signax/__init__.py
@@ -5,6 +5,7 @@ __version__ = "0.2.1"
 __all__ = (
     "__version__",
     "module",
+    "pallas_kernels",
     "utils",
     "tensor_ops",
     "signature",
@@ -14,7 +15,7 @@ __all__ = (
     "multi_signature_combine",
 )
 
-from signax import module, tensor_ops, utils
+from signax import module, pallas_kernels, tensor_ops, utils
 from signax.signatures import (
     logsignature,
     multi_signature_combine,

--- a/src/signax/pallas_kernels.py
+++ b/src/signax/pallas_kernels.py
@@ -1,0 +1,484 @@
+"""Pallas GPU kernel implementations for signax.
+
+These kernels require a CUDA-capable GPU (JAX Triton backend). On CPU-only
+hosts they fall back automatically to the pure-JAX equivalents in
+:mod:`signax.tensor_ops` and :mod:`signax.signatures`.
+
+Three kernels are provided, corresponding to PLAN.md §4.1-4.3:
+
+* :func:`restricted_exp_pallas` (§4.1) — fused restricted exponential that
+  loads the ``dim``-element input vector once and computes all depth levels in
+  a single kernel launch, eliminating repeated HBM reads.
+
+* :func:`signature_scan_pallas` (§4.2) — tiled path-scan kernel that keeps
+  the running signature in on-chip SRAM across time-steps within a tile,
+  trading kernel-launch overhead for bandwidth savings on long paths.
+
+* :func:`batched_signature_pallas` (§4.3) — batched kernel that assigns each
+  (batch, tile) pair to its own thread-block, exposing inter-batch parallelism
+  that ``vmap`` alone cannot exploit for small batch sizes.
+
+Usage::
+
+    from signax.pallas_kernels import (
+        restricted_exp_pallas,
+        signature_scan_pallas,
+        batched_signature_pallas,
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import partial
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+from signax.tensor_ops import restricted_exp
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Pallas availability guard
+# ---------------------------------------------------------------------------
+
+try:
+    import jax.experimental.pallas as pl
+
+    _PALLAS_AVAILABLE = True
+except Exception:
+    pl = None
+    _PALLAS_AVAILABLE = False
+
+if not _PALLAS_AVAILABLE:
+    logger.warning(
+        "jax.experimental.pallas is not available. "
+        "signax.pallas_kernels will use pure-JAX fallbacks."
+    )
+
+
+def is_gpu_available() -> bool:
+    """Return True when a CUDA GPU backend is reachable by JAX."""
+    try:
+        return any(d.platform == "gpu" for d in jax.devices())
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# §4.1  Fused restricted_exp kernel
+# ---------------------------------------------------------------------------
+
+
+def _restricted_exp_kernel(
+    input_ref: Any,
+    *out_refs: Any,
+    depth: int,
+) -> None:
+    """Pallas kernel body for the fused restricted exponential (§4.1).
+
+    Loads ``input`` once into registers and computes all depth levels via
+    successive outer products, writing each level to its own output ref.
+
+    Grid design
+    -----------
+    grid = (1,)
+        A single CTA handles the full computation. This is appropriate when
+        ``dim ≤ 32`` (the input fits in registers). For larger ``dim``, tile
+        the computation over the leading output dimension and adjust
+        ``in_specs`` / ``out_specs`` accordingly.
+
+    Args:
+        input_ref: BlockRef of shape ``(dim,)``.
+        *out_refs: ``depth`` BlockRefs with shapes ``(dim,)``,
+            ``(dim, dim)``, …, ``(dim,) * depth``.
+        depth: Signature truncation depth (static).
+    """
+    x = input_ref[...]  # (dim,) — loaded once into registers
+
+    prev = x
+    out_refs[0][...] = prev  # depth-1 level: shape (dim,)
+
+    for d in range(2, depth + 1):
+        # Outer product via broadcasting: shape grows by one trailing dim each step.
+        # prev[..., None] broadcasts over the new dim; x is already (dim,).
+        prev = prev[..., None] * (x / d)
+        out_refs[d - 1][...] = prev  # shape (dim,) * d
+
+
+@partial(jax.jit, static_argnames=("depth",))
+def restricted_exp_pallas(
+    input: jax.Array,
+    depth: int,
+) -> list[jax.Array]:
+    """Fused restricted exponential via a single Pallas kernel launch (§4.1).
+
+    Equivalent to :func:`signax.tensor_ops.restricted_exp` but loads ``input``
+    once and computes all ``depth`` levels in one GPU kernel, eliminating
+    ``depth - 1`` redundant HBM reads.
+
+    Falls back to the pure-JAX implementation when Pallas is unavailable or
+    no GPU is detected.
+
+    Args:
+        input: 1-D array of shape ``(dim,)``.
+        depth: Signature truncation depth.
+
+    Returns:
+        List of arrays ``[input, input⊗input/2, …]`` with shapes
+        ``(dim,), (dim, dim), …, (dim,) * depth``.
+    """
+    if not _PALLAS_AVAILABLE or not is_gpu_available():
+        return restricted_exp(input, depth)
+
+    dim = input.shape[0]
+    out_shapes = [
+        jax.ShapeDtypeStruct((dim,) * d, input.dtype) for d in range(1, depth + 1)
+    ]
+
+    return pl.pallas_call(
+        partial(_restricted_exp_kernel, depth=depth),
+        out_shape=out_shapes,
+        grid=(1,),
+    )(input)
+
+
+# ---------------------------------------------------------------------------
+# §4.2  Fused signature path-scan kernel
+# ---------------------------------------------------------------------------
+
+
+def _signature_scan_kernel_fn(
+    increments_ref: Any,
+    sig_in_ref: Any,
+    sig_out_ref: Any,
+    *,
+    depth: int,
+    dim: int,
+    chunk_size: int,
+) -> None:
+    """Pallas kernel body for the tiled path-scan (§4.2).
+
+    Each CTA processes ``chunk_size`` consecutive path increments, keeping
+    the running signature flat-vector in on-chip SRAM between time-steps.
+    After processing all increments in the tile the updated signature is
+    written back to HBM via ``sig_out_ref``.
+
+    Grid design
+    -----------
+    grid = (num_tiles,)
+        One CTA per tile; tiles are processed sequentially by the host via
+        a ``jax.lax.scan`` over the output signatures (Chen's identity
+        guarantees that each tile's output depends only on the previous
+        tile's final signature).
+
+    Memory layout
+    -------------
+    The running signature is stored as a flat 1-D vector of total size
+    ``dim + dim² + … + dim^depth``.  Within the kernel the depth-level
+    boundaries are computed as static Python ints (both ``depth`` and
+    ``dim`` are compile-time constants when the kernel is JIT-compiled).
+
+    Args:
+        increments_ref: BlockRef of shape ``(chunk_size, dim)`` — one tile
+            of path increments.
+        sig_in_ref: BlockRef of shape ``(total_sig_size,)`` — running
+            signature entering this tile (identity for the first tile).
+        sig_out_ref: BlockRef of shape ``(total_sig_size,)`` — updated
+            running signature after this tile.
+        depth: Signature truncation depth (static).
+        dim: Path dimension (static).
+        chunk_size: Number of increments per tile (static).
+
+    TODO
+    ----
+    Implement the inner ``mult_fused_restricted_exp`` call in terms of the
+    flat-vector signature layout so that the entire update runs in registers
+    without intermediate HBM traffic.  The high-level logic is::
+
+        sig_flat = sig_in_ref[...]
+        for t in range(chunk_size):
+            dz = increments_ref[t, :]
+            sig_flat = _flat_mult_fused_restricted_exp(sig_flat, dz, dim, depth)
+        sig_out_ref[...] = sig_flat
+    """
+    # Placeholder: pass-through until flat mult_fused_restricted_exp is wired up.
+    sig_out_ref[...] = sig_in_ref[...]
+
+
+def _signature_scan_fallback(
+    path: jax.Array,
+    depth: int,
+) -> list[jax.Array]:
+    """Pure-JAX fallback for :func:`signature_scan_pallas`."""
+    from signax.signatures import _signature  # local import to avoid circularity
+
+    return _signature(path, depth=depth, stream=False, flatten=False)
+
+
+@partial(jax.jit, static_argnames=("depth", "chunk_size"))
+def signature_scan_pallas(
+    path: jax.Array,
+    depth: int,
+    chunk_size: int = 64,
+) -> list[jax.Array]:
+    """Tiled path-scan signature via Pallas (§4.2).
+
+    Divides the path into tiles of ``chunk_size`` increments. Within each
+    tile a single GPU CTA processes all increments while keeping the running
+    signature in on-chip SRAM. Tiles are chained via Chen's identity.
+
+    Expected gain
+    -------------
+    Up to 4-8x reduction in HBM reads for long paths (``path_len ≫ chunk_size``)
+    compared to the ``jax.lax.scan`` baseline, by keeping the running signature
+    in fast on-chip memory across multiple time-steps.
+
+    Constraint
+    ----------
+    Requires ``dim^depth x sizeof(dtype) ≤ available SRAM per CTA`` (e.g.
+    ``dim=8, depth=4`` ⟹ 4096 float32 values = 16 KB — feasible on most
+    modern GPUs).  Larger configurations fall back to the pure-JAX scan.
+
+    Falls back to the pure-JAX implementation when Pallas is unavailable or
+    no GPU is detected.
+
+    Args:
+        path: Array of shape ``(path_len, dim)``.
+        depth: Signature truncation depth.
+        chunk_size: Number of increments processed per CTA tile.
+
+    Returns:
+        List of arrays with shapes ``(dim,), (dim, dim), …, (dim,) * depth``.
+    """
+    if not _PALLAS_AVAILABLE or not is_gpu_available():
+        return _signature_scan_fallback(path, depth)
+
+    path_len, dim = path.shape
+    increments = jnp.diff(path, axis=0)  # (path_len - 1, dim)
+    num_steps = path_len - 1
+
+    # Pad so that num_steps is a multiple of chunk_size.
+    remainder = num_steps % chunk_size
+    if remainder != 0:
+        pad_len = chunk_size - remainder
+        increments = jnp.pad(increments, ((0, pad_len), (0, 0)))
+        num_steps_padded = num_steps + pad_len
+    else:
+        num_steps_padded = num_steps
+
+    num_tiles = num_steps_padded // chunk_size
+    increments_tiled = increments.reshape(num_tiles, chunk_size, dim)
+
+    sizes: list[int] = [dim**d for d in range(1, depth + 1)]
+    total_sig = sum(sizes)
+
+    # Build per-tile output shapes: each tile outputs an updated sig vector.
+    out_shape_per_tile = jax.ShapeDtypeStruct((total_sig,), path.dtype)
+
+    # Chain tiles via lax.scan (Chen's identity): each tile takes the
+    # previous tile's final sig as its initial sig.
+    init_sig = jnp.zeros(total_sig, dtype=path.dtype)
+
+    def tile_body(
+        carry_sig: jax.Array, tile_increments: jax.Array
+    ) -> tuple[jax.Array, jax.Array]:
+        out_sig = pl.pallas_call(
+            partial(
+                _signature_scan_kernel_fn,
+                depth=depth,
+                dim=dim,
+                chunk_size=chunk_size,
+            ),
+            out_shape=out_shape_per_tile,
+            grid=(1,),
+        )(tile_increments, carry_sig)
+        return out_sig, out_sig
+
+    final_sig, _ = jax.lax.scan(tile_body, init_sig, increments_tiled)
+
+    # Unpack flat sig into depth-level list.
+    offsets: list[int] = []
+    off = 0
+    for s in sizes:
+        offsets.append(off)
+        off += s
+
+    return [
+        final_sig[offsets[d] : offsets[d] + sizes[d]].reshape((dim,) * (d + 1))
+        for d in range(depth)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# §4.3  Batched parallel signature kernel
+# ---------------------------------------------------------------------------
+
+
+def _batched_signature_kernel_fn(
+    path_tile_ref: Any,
+    partial_sig_ref: Any,
+    *,
+    depth: int,
+    dim: int,
+    tile_size: int,
+) -> None:
+    """Pallas kernel body for the batched parallel signature (§4.3).
+
+    Grid design
+    -----------
+    grid = (batch_size, num_tiles)
+        axis-0 indexes the batch element; axis-1 indexes the path tile.
+        Each CTA owns one (batch, tile) pair, accumulates a partial
+        signature for that tile in registers, then writes it to HBM.
+        The host combines partial signatures across tiles via Chen's
+        identity using :func:`signax.signatures.multi_signature_combine`.
+
+    Args:
+        path_tile_ref: BlockRef of shape ``(tile_size, dim)`` — one tile of
+            increments for one batch element.
+        partial_sig_ref: BlockRef of shape ``(total_sig_size,)`` — partial
+            signature output for this (batch, tile) pair.
+        depth: Signature truncation depth (static).
+        dim: Path dimension (static).
+        tile_size: Number of increments per tile (static).
+
+    TODO
+    ----
+    Replace the placeholder with the same flat-vector
+    ``mult_fused_restricted_exp`` used in :func:`_signature_scan_kernel_fn`,
+    accumulating over ``tile_size`` increments in a register loop::
+
+        sig_flat = jnp.zeros(total_sig_size, dtype=path_tile_ref.dtype)
+        for t in range(tile_size):
+            dz = path_tile_ref[t, :]
+            sig_flat = _flat_mult_fused_restricted_exp(sig_flat, dz, dim, depth)
+        partial_sig_ref[...] = sig_flat
+    """
+    # Placeholder: write zeros (identity signature) until the inner loop is wired.
+    sizes: list[int] = [dim**d for d in range(1, depth + 1)]
+    total = sum(sizes)
+    partial_sig_ref[...] = jnp.zeros(total, dtype=jnp.float32)
+
+
+def _batched_signature_fallback(
+    paths: jax.Array,
+    depth: int,
+) -> list[jax.Array]:
+    """Pure-JAX fallback for :func:`batched_signature_pallas`."""
+    from signax.signatures import _signature  # local import to avoid circularity
+
+    sig_fun = partial(_signature, depth=depth, stream=False, flatten=False)
+    return jax.vmap(sig_fun)(paths)
+
+
+@partial(jax.jit, static_argnames=("depth", "tile_size"))
+def batched_signature_pallas(
+    paths: jax.Array,
+    depth: int,
+    tile_size: int = 64,
+) -> list[jax.Array]:
+    """Batched parallel signature via Pallas (§4.3).
+
+    Assigns each ``(batch, tile)`` pair to a dedicated GPU CTA, exposing
+    inter-batch parallelism that ``jax.vmap`` alone cannot exploit when the
+    batch size is small relative to the GPU's SM count.
+
+    Grid: ``(batch_size, num_tiles)``
+    Block: one CTA per ``(batch, tile)`` pair, accumulating a partial
+    signature for that tile in registers.  Partial signatures are combined
+    across tiles on the host via Chen's identity.
+
+    Args:
+        paths: Array of shape ``(batch, path_len, dim)``.
+        depth: Signature truncation depth.
+        tile_size: Number of increments processed per CTA tile.
+
+    Returns:
+        List of arrays with shapes
+        ``(batch, dim), (batch, dim, dim), …, (batch,) + (dim,) * depth``.
+    """
+    if not _PALLAS_AVAILABLE or not is_gpu_available():
+        return _batched_signature_fallback(paths, depth)
+
+    batch_size, path_len, dim = paths.shape
+    increments = jnp.diff(paths, axis=1)  # (batch, path_len - 1, dim)
+    num_steps = path_len - 1
+
+    # Pad to a multiple of tile_size.
+    remainder = num_steps % tile_size
+    if remainder != 0:
+        pad_len = tile_size - remainder
+        increments = jnp.pad(increments, ((0, 0), (0, pad_len), (0, 0)))
+        num_steps_padded = num_steps + pad_len
+    else:
+        num_steps_padded = num_steps
+
+    num_tiles = num_steps_padded // tile_size
+    # (batch, num_tiles, tile_size, dim)
+    inc_tiled = increments.reshape(batch_size, num_tiles, tile_size, dim)
+
+    sizes: list[int] = [dim**d for d in range(1, depth + 1)]
+    total_sig = sum(sizes)
+
+    # One pallas_call per tile, vmapped over (batch, tile).
+    # Shape out: (batch, num_tiles, total_sig)
+    partial_sigs = jax.vmap(
+        jax.vmap(
+            pl.pallas_call(
+                partial(
+                    _batched_signature_kernel_fn,
+                    depth=depth,
+                    dim=dim,
+                    tile_size=tile_size,
+                ),
+                out_shape=jax.ShapeDtypeStruct((total_sig,), paths.dtype),
+                grid=(1,),
+            )
+        )
+    )(inc_tiled)
+    # partial_sigs: (batch, num_tiles, total_sig)
+
+    # Combine tiles via Chen's identity using a sequential scan per batch element.
+    offsets: list[int] = []
+    off = 0
+    for s in sizes:
+        offsets.append(off)
+        off += s
+
+    def unpack(flat: jax.Array) -> list[jax.Array]:
+        return [
+            flat[offsets[d] : offsets[d] + sizes[d]].reshape((dim,) * (d + 1))
+            for d in range(depth)
+        ]
+
+    def pack(sig_list: list[jax.Array]) -> jax.Array:
+        return jnp.concatenate([s.ravel() for s in sig_list])
+
+    def combine_tiles(partial_sigs_batch: jax.Array) -> jax.Array:
+        # partial_sigs_batch: (num_tiles, total_sig)
+        def body(
+            carry_flat: jax.Array, tile_flat: jax.Array
+        ) -> tuple[jax.Array, jax.Array]:
+            carry = unpack(carry_flat)
+            tile_sig = unpack(tile_flat)
+            from signax.signatures import signature_combine  # avoid circularity
+
+            combined = pack(signature_combine(carry, tile_sig))
+            return combined, combined
+
+        init = partial_sigs_batch[0]
+        final, _ = jax.lax.scan(body, init, partial_sigs_batch[1:])
+        return final
+
+    final_flat = jax.vmap(combine_tiles)(partial_sigs)  # (batch, total_sig)
+
+    # Unpack into depth-level list with leading batch dimension.
+    return [
+        final_flat[:, offsets[d] : offsets[d] + sizes[d]].reshape(
+            (batch_size,) + (dim,) * (d + 1)
+        )
+        for d in range(depth)
+    ]

--- a/src/signax/tensor_ops.py
+++ b/src/signax/tensor_ops.py
@@ -30,6 +30,54 @@ def addcmul(x: jax.Array, y: jax.Array, z: jax.Array) -> jax.Array:
     return x + otimes(y, z)
 
 
+_UNROLL_THRESHOLD = 5
+
+
+def _restricted_exp_unrolled(input: jax.Array, depth: int) -> list[jax.Array]:
+    """Python-unrolled variant; generates a flat XLA chain at trace time."""
+    ret = [input]
+    for i in range(2, depth + 1):
+        ret.append(otimes(ret[-1], input / i))
+    return ret
+
+
+def _restricted_exp_flat(input: jax.Array, depth: int) -> list[jax.Array]:
+    """Flat-buffer variant for depth > _UNROLL_THRESHOLD.
+
+    Stores all depth levels in one contiguous 1-D JAX array, then extracts
+    each level at the end.  Slice indices are Python ints (dim and depth are
+    both concrete at JIT-trace time), so no dynamic indexing overhead is
+    incurred.
+
+    Note: a true single-construct XLA loop (jax.lax.fori_loop) would further
+    reduce the compiled graph node count but requires a fixed-shape carry,
+    which is incompatible with the per-level size growth dim^1 … dim^depth.
+    The flat-buffer layout at least makes the memory pattern explicit and
+    provides a direct foundation for a future padded-carry implementation.
+    """
+    dim = input.shape[0]
+    sizes: list[int] = [dim**d for d in range(1, depth + 1)]
+    offsets: list[int] = []
+    off = 0
+    for s in sizes:
+        offsets.append(off)
+        off += s
+
+    flat = jnp.zeros(off, dtype=input.dtype)
+    flat = flat.at[offsets[0] : offsets[0] + sizes[0]].set(input)
+
+    for d in range(1, depth):
+        prev_flat = flat[offsets[d - 1] : offsets[d - 1] + sizes[d - 1]]
+        prev = prev_flat.reshape((dim,) * d)
+        nxt = otimes(prev, input / (d + 1))
+        flat = flat.at[offsets[d] : offsets[d] + sizes[d]].set(nxt.ravel())
+
+    return [
+        flat[offsets[d] : offsets[d] + sizes[d]].reshape((dim,) * (d + 1))
+        for d in range(depth)
+    ]
+
+
 @partial(jax.jit, static_argnames="depth")
 def restricted_exp(input: jax.Array, depth: int) -> list[jax.Array]:
     """Restricted exponentiate
@@ -42,10 +90,9 @@ def restricted_exp(input: jax.Array, depth: int) -> list[jax.Array]:
     Return:
         A list of `jnp.ndarray` contains tensors
     """
-    ret = [input]
-    for i in range(2, depth + 1):
-        ret.append(otimes(ret[-1], input / i))
-    return ret
+    if depth <= _UNROLL_THRESHOLD:
+        return _restricted_exp_unrolled(input, depth)
+    return _restricted_exp_flat(input, depth)
 
 
 @jax.jit


### PR DESCRIPTION
## Summary

- **§3.4** (`tensor_ops.py`): Add `_restricted_exp_flat()` — a flat contiguous-buffer variant of `restricted_exp` for `depth > 5`. Dispatch added to `restricted_exp()` via `_UNROLL_THRESHOLD`. Lays the groundwork for a future `jax.lax.fori_loop` variant (blocked by JAX's fixed-shape carry requirement; documented in code).
- **§4.1** (`pallas_kernels.py`): `restricted_exp_pallas` — single-launch Pallas kernel that loads the `dim`-element input vector once into registers and computes all depth levels via successive outer products. Falls back to pure-JAX on CPU.
- **§4.2** (`pallas_kernels.py`): `signature_scan_pallas` — tiled path-scan kernel with a `(num_tiles,)` grid; each CTA keeps the running signature in on-chip SRAM across `chunk_size` time-steps. Kernel body is a placeholder pending a flat-vector `mult_fused_restricted_exp`; host-level tile chaining via `jax.lax.scan` + Chen's identity is wired up.
- **§4.3** (`pallas_kernels.py`): `batched_signature_pallas` — `(batch, tile)` grid exposing inter-batch parallelism; partial signatures combined on the host via Chen's identity. Kernel body is a placeholder.

## Notes

- No tests: GPU not yet available in CI. Tests should be added once a CUDA device is reachable.
- All three kernels auto-detect GPU presence and fall back to pure-JAX when unavailable — existing CPU tests are unaffected.
- Pre-commit (black, ruff, mypy) passes cleanly.

## Test plan

- [ ] Confirm `import signax.pallas_kernels` succeeds on CPU (fallback path)
- [ ] On GPU: verify `restricted_exp_pallas` output matches `restricted_exp` for dim ∈ {3, 8, 32}, depth ∈ {2, 4, 6}
- [ ] On GPU: fill in `_signature_scan_kernel_fn` body and verify `signature_scan_pallas` matches `_signature`
- [ ] On GPU: fill in `_batched_signature_kernel_fn` body and verify `batched_signature_pallas` matches `vmap(_signature)`
- [ ] Benchmark `restricted_exp_pallas` vs `restricted_exp` for dim=8, depth=6, batch=256

🤖 Generated with [Claude Code](https://claude.com/claude-code)